### PR TITLE
Add pre-commit framework support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: aikido-local-scanner
+  name: Aikido Secrets Scanner
+  description: Scan staged code for secrets, passwords, and API keys
+  entry: aikido-local-scanner-wrapper
+  language: script
+  types: [text]
+  stages: [pre-commit]
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,48 @@
 
 The Aikido Secrets pre-commit hook scans your staged code for secrets, passwords and API keys. It stops sensitive data from ever reaching your repository, which reduces the risk of leaks and accidental exposure.
 
-This repository contains installation script samples for different platforms and installation methods.
+## Installation
+
+### Option 1: Pre-commit Framework
+
+If you're already using the [pre-commit](https://pre-commit.com/) framework, add this to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/AikidoSec/pre-commit
+    rev: main  # or pin to a specific commit
+    hooks:
+      - id: aikido-local-scanner
+```
+
+Then install the hooks:
+
+```bash
+pre-commit install
+```
+
+**Note:** The `aikido-local-scanner` binary must be installed separately. Run the global installation script first:
+
+```bash
+# macOS/Linux
+curl -fsSL https://raw.githubusercontent.com/AikidoSec/pre-commit/main/installation-samples/install-global/install-aikido-hook.sh | bash
+```
+
+This installs the scanner to `~/.local/bin/aikido-local-scanner`.
+
+### Option 2: Global Installation
+
+To install the hook globally (applies to all repositories):
+
+**macOS/Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/AikidoSec/pre-commit/main/installation-samples/install-global/install-aikido-hook.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+iex (iwr "https://raw.githubusercontent.com/AikidoSec/pre-commit/main/installation-samples/install-global/install-aikido-hook.ps1" -UseBasicParsing)
+```
 
 ## More Information
 

--- a/aikido-local-scanner-wrapper
+++ b/aikido-local-scanner-wrapper
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Wrapper script for aikido-local-scanner pre-commit hook
+# This script is called by the pre-commit framework
+#
+
+set -e
+
+# Default install location (matches install-aikido-hook.sh)
+DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+BINARY_NAME="aikido-local-scanner"
+
+# Check common locations for the scanner
+find_scanner() {
+    # Check if it's in PATH
+    if command -v "${BINARY_NAME}" &> /dev/null; then
+        echo "${BINARY_NAME}"
+        return 0
+    fi
+
+    # Check default install location
+    if [ -x "${DEFAULT_INSTALL_DIR}/${BINARY_NAME}" ]; then
+        echo "${DEFAULT_INSTALL_DIR}/${BINARY_NAME}"
+        return 0
+    fi
+
+    return 1
+}
+
+SCANNER=$(find_scanner) || {
+    echo "❌ aikido-local-scanner not found."
+    echo ""
+    echo "Please install the Aikido scanner first:"
+    echo ""
+    echo "  curl -fsSL https://raw.githubusercontent.com/AikidoSec/pre-commit/main/installation-samples/install-global/install-aikido-hook.sh | bash"
+    echo ""
+    echo "Or download manually from: https://help.aikido.dev/code-scanning/local-code-scanning/aikido-secrets-pre-commit-hook"
+    exit 1
+}
+
+# Get the repository root
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Run the scanner
+exec "${SCANNER}" pre-commit-scan "${REPO_ROOT}"


### PR DESCRIPTION
## Summary

This PR adds support for the [pre-commit](https://pre-commit.com/) framework by adding:

1. **`.pre-commit-hooks.yaml`** - Defines the `aikido-local-scanner` hook for the pre-commit framework
2. **`aikido-local-scanner-wrapper`** - A wrapper script that finds and runs the scanner binary
3. **Updated README** - Documents both installation methods

## Usage

After this change, users can add Aikido to their `.pre-commit-config.yaml`:

```yaml
repos:
  - repo: https://github.com/AikidoSec/pre-commit
    rev: main  # or pin to a specific commit
    hooks:
      - id: aikido-local-scanner
```

The scanner binary still needs to be installed separately (the wrapper provides clear instructions if not found).

## Benefits

- Standard integration with pre-commit framework
- Per-project configuration instead of global-only
- Version pinning support (can pin to specific commits)
- Works alongside other security scanning hooks
- Cleaner integration for teams already using pre-commit

## Testing

1. Install the scanner binary using the existing installation script
2. Add the hook to a `.pre-commit-config.yaml`
3. Run `pre-commit run aikido-local-scanner --all-files`

Fixes #3

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
**🚀 New Features**
* Added pre-commit hook configuration file for Aikido scanner
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->